### PR TITLE
adds a palette attribute to bind to a set of colors

### DIFF
--- a/src/js/spectrumColorpicker.directive.js
+++ b/src/js/spectrumColorpicker.directive.js
@@ -10,7 +10,7 @@
         format: '=?',
         options: '=?',
         triggerId: '@?',
-
+		palette : '=?',
         onChange: '&?',
         onShow: '&?',
         onHide: '&?',
@@ -89,6 +89,10 @@
             return $scope.onBeforeShow({color: formatColor(color)});
           };
         }
+		
+		if ($scope.palette) {
+          localOpts.palette = $scope.palette;
+        }
 
         var options = angular.extend({}, baseOpts, $scope.options, localOpts);
 
@@ -105,8 +109,8 @@
           $input.spectrum('set', options.color || '');
           setViewValue(options.color);
         }
-
-        $input.spectrum(options);
+		 
+		$input.spectrum(options);
 
         $scope.$on('$destroy', function() {
           if ($scope.triggerId) {
@@ -121,7 +125,11 @@
 
         $scope.$watch('disabled', function (newDisabled) {
           $input.spectrum(newDisabled ? 'disable' : 'enable');
-        });
+        });		
+
+		$scope.$watch('palette', function (palette) {
+		  $input.spectrum('option', 'palette', palette);
+		});
       }
     };
   });

--- a/test/unit/spectrumDirectiveSpec.js
+++ b/test/unit/spectrumDirectiveSpec.js
@@ -77,7 +77,7 @@ describe('SpectrumDirective', function() {
         'options': 'options'
       });
       expect(d.elm.find('input').attr('disabled')).toBe('disabled');
-    });
+    });	
 
     describe('trigger handler', function() {
       var $label;
@@ -139,6 +139,34 @@ describe('SpectrumDirective', function() {
       expect($('.sp-container').length).toBe(1);
       d.scope.$destroy();
       expect($('.sp-container').length).toBe(0);
+    });	
+	
+	it('should set palette via evaluated value', function() {
+      var input = ['#FFF', '#000'], output = ['rgb(255, 255, 255)', 'rgb(0, 0, 0)'];
+      $rootScope.palette = [input];      
+	  $rootScope.options = {
+        showPalette: true
+      };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'palette': 'palette',
+		'options': 'options'
+      });
+
+      $('.sp-palette .sp-thumb-el').each(function(index, el){ 
+			expect($(el).html()).toContain(output[index]);
+	  });	  
+	  expect($('.sp-palette .sp-thumb-el').length).toBe(2);
+	  
+		it('should update palette via evaluated value', function() {
+		  var input = ['#000'], output = ['rgb(0, 0, 0)'];
+		  $rootScope.palette = [input];  
+		  $rootScope.digest();
+		  $('.sp-palette .sp-thumb-el').each(function(index, el){ 
+				expect($(el).html()).toContain(output[index]);
+		  });	  
+		  expect($('.sp-palette .sp-thumb-el').length).toBe(1);
+		});	  
     });
 
     it('should cope with falsy color values', function() {


### PR DESCRIPTION
Add an attribute to bind to a color palette easier:
`
        <spectrum-colorpicker palette="colors">
        </spectrum-colorpicker>
`

(We were having issues getting the colors to bind initially and update when dynamically generated by a service)