### PR TITLE
add update options for spectrum events

### DIFF
--- a/src/js/spectrumColorpicker.directive.js
+++ b/src/js/spectrumColorpicker.directive.js
@@ -17,6 +17,11 @@
         onMove: '&?',
 
         onBeforeShow: '&?',
+		
+	    onChangeOptions: '=?',
+	    onShowOptions: '=?',
+	    onHideOptions: '=?',
+	    onMoveOptions: '=?'
       },
       replace: true,
       templateUrl: 'directive.html',
@@ -68,21 +73,27 @@
 
         var localOpts = {};
 
-        angular.forEach({
-          'change': 'onChange',
-          'move': 'onMove',
-          'hide': 'onHide',
-          'show': 'onShow'
-        }, function(eventKey, spectrumOptionName) {
-          localOpts[spectrumOptionName] = function(color) {
-            onChange(color);
-            // we don't do this for change, because we expose the current
-            // value actively through the model
-            if (eventKey !== 'change' && angular.isFunction($scope[eventKey])) {
-              return $scope[eventKey]({color: formatColor(color)});
-            }
-          };
-        });
+            angular.forEach({
+                'change': 'onChange',
+                'move': 'onMove',
+                'hide': 'onHide',
+                'show': 'onShow',
+            },
+            function (eventHandlerName, eventName) {
+                var spectrumEventHandlerOptions = $scope[eventHandlerName + 'Options'];
+                localOpts[eventName] = function (color) {
+                    if (!spectrumEventHandlerOptions || spectrumEventHandlerOptions.update) {
+                        onChange(color);
+                    }
+                    // we don't do this for change, because we expose the current
+                    // value actively through the model
+                    if (eventHandlerName !== 'change' && angular.isFunction($scope[eventHandlerName])) {
+                        return $scope[eventHandlerName]({ color: formatColor(color) });
+                    } else {
+                        return null;
+                    }
+               };
+          });
 
         if (angular.isFunction($scope.onBeforeShow)) {
           localOpts.beforeShow = function(color) {

--- a/test/unit/spectrumDirectiveSpec.js
+++ b/test/unit/spectrumDirectiveSpec.js
@@ -227,7 +227,191 @@ describe('SpectrumDirective', function() {
     beforeEach(function() {
       initGlobals();
     });
+	
+	it('should propagate change to color on change', function() {
+	  var color = '#FFF';
+	  $rootScope.targetColor = jasmine.createSpy('targetColor');
+	  $rootScope.targetColor.and.callFake(function(value){
+		  if(angular.isDefined(value)){
+			color = value;
+		  }
+		  return color;
+	  });
+	  $rootScope.options = {		  
+            showPalette: true
+	  };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'ng-model-options': '{ getterSetter : true }',
+		'options' : 'options'
+      });
+      
+      $('input.sp-input').val(color).trigger('change');
+      expect($rootScope.targetColor).toHaveBeenCalledWith(color);
+    });
+	
+	it('should not propagate change to color on change with update option set to false', function() {
+	  var color = '#FFF';
+	  $rootScope.targetColor = jasmine.createSpy('targetColor');
+	  $rootScope.targetColor.and.callFake(function(value){
+		  if(angular.isDefined(value)){
+			color = value;
+		  }
+		  return color;
+	  });
+	  $rootScope.options = {		  
+            showPalette: true
+	  };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'ng-model-options': '{ getterSetter : true }',
+		'on-change-options' : '{ update : false }',
+		'options' : 'options'
+      });
+      
+      $('input.sp-input').val(color).trigger('change');
+      expect($rootScope.targetColor).not.toHaveBeenCalledWith(color);
+    });
 
+	it('should propagate change to color on show', function() {
+	  var color = '#FFF';
+	  $rootScope.targetColor = jasmine.createSpy('targetColor');
+	  $rootScope.targetColor.and.callFake(function(value){
+		  if(angular.isDefined(value)){
+			color = value;
+		  }
+		  return color;
+	  });
+	  $rootScope.options = {		  
+            showPalette: true
+	  };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'ng-model-options': '{ getterSetter : true }',
+		'options' : 'options'
+      });
+      d.elm.find('input').spectrum('show');
+      expect($rootScope.targetColor).toHaveBeenCalledWith(color);
+    });
+	
+	it('should not propagate change to color on show with update option set to false', function() {
+	  var color = '#FFF';
+	  $rootScope.targetColor = jasmine.createSpy('targetColor');
+	  $rootScope.targetColor.and.callFake(function(value){
+		  if(angular.isDefined(value)){
+			color = value;
+		  }
+		  return color;
+	  });
+	  $rootScope.options = {		  
+            showPalette: true
+	  };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'ng-model-options': '{ getterSetter : true }',
+		'on-show-options' : '{ update : false }',
+		'options' : 'options'
+      });
+      d.elm.find('input').spectrum('show');
+      expect($rootScope.targetColor).not.toHaveBeenCalledWith(color);
+    });
+	
+	it('should propagate change to color on hide', function() {
+	  var color = '#FFF';
+	  $rootScope.targetColor = jasmine.createSpy('targetColor');
+	  $rootScope.targetColor.and.callFake(function(value){
+		  if(angular.isDefined(value)){
+			color = value;
+		  }
+		  return color;
+	  });
+	  $rootScope.options = {		  
+            showPalette: true
+	  };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'ng-model-options': '{ getterSetter : true }',
+		'on-show-options' : '{ update : false }',
+		'options' : 'options'
+      });
+	  
+      d.elm.find('input').spectrum('show');
+      d.elm.find('input').spectrum('hide');
+      expect($rootScope.targetColor).toHaveBeenCalledWith(color);
+    });
+	
+	it('should not propagate change to color on hide with update option set to false', function() {
+	  var color = '#FFF';
+	  $rootScope.targetColor = jasmine.createSpy('targetColor');
+	  $rootScope.targetColor.and.callFake(function(value){
+		  if(angular.isDefined(value)){
+			color = value;
+		  }
+		  return color;
+	  });
+	  $rootScope.options = {		  
+            showPalette: true
+	  };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'ng-model-options': '{ getterSetter : true }',
+		'on-show-options' : '{ update : false }',
+		'on-hide-options' : '{ update : false }',
+		'options' : 'options'
+      });
+	  d.elm.find('input').spectrum('show');
+      d.elm.find('input').spectrum('hide');
+      expect($rootScope.targetColor).not.toHaveBeenCalledWith(color);
+    });
+	
+	it('should propagate change to color on move', function() {
+	  var color = '#FFF';
+	  $rootScope.targetColor = jasmine.createSpy('targetColor');
+	  $rootScope.targetColor.and.callFake(function(value){
+		  if(angular.isDefined(value)){
+			color = value;
+		  }
+		  return color;
+	  });
+	  $rootScope.options = {		  
+            showPalette: true
+	  };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'ng-model-options': '{ getterSetter : true }',
+		'on-show-options' : '{ update : false }',
+		'options' : 'options'
+      });
+	  
+      d.elm.find('input').spectrum('show');
+      $(document).find('.sp-clear').click();
+      expect($rootScope.targetColor).toHaveBeenCalledWith(color);
+    });
+	
+	it('should not propagate change to color on move with update option set to false', function() {
+	  var color = '#FFF';
+	  $rootScope.targetColor = jasmine.createSpy('targetColor');
+	  $rootScope.targetColor.and.callFake(function(value){
+		  if(angular.isDefined(value)){
+			color = value;
+		  }
+		  return color;
+	  });
+	  $rootScope.options = {		  
+            showPalette: true
+	  };
+      var d = createDirective({
+        'ng-model': 'targetColor',
+        'ng-model-options': '{ getterSetter : true }',
+		'on-show-options' : '{ update : false }',
+		'on-move-options' : '{ update : false }',
+		'options' : 'options'
+      });
+	  d.elm.find('input').spectrum('show');
+      $(document).find('.sp-clear').click();
+      expect($rootScope.targetColor).not.toHaveBeenCalledWith(color);
+    });
+	
     it('should correctly emit change event', function() {
       $rootScope.eventSpy = jasmine.createSpy('change');
       var d = createDirective({
@@ -238,8 +422,8 @@ describe('SpectrumDirective', function() {
       $rootScope.targetColor = 'blue';
       expect($rootScope.eventSpy).toHaveBeenCalled();
     });
-
-    it('should correctly emit show event', function() {
+	
+	it('should correctly emit show event', function() {
       $rootScope.eventSpy = jasmine.createSpy('show');
       var d = createDirective({
         'ng-model': 'targetColor',


### PR DESCRIPTION
Add attributes to stop updating on specific spectrum events, example:
`
        <spectrum-colorpicker  on-show-options="{ update : false }"
                              on-hide-options="{ update : false }">
        </spectrum-colorpicker>
`
(which we needed to stop assigning wrong colors to model binding with a getter and setter that compares then read from and assigns to multiple objects based on additional criteria)